### PR TITLE
Add mod-provided API and enable update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 **SimpleSprinkler** is a [Stardew Valley](http://stardewvalley.net/) mod which lets you customise
 the sprinkler coverage radius by editing the `config.json`.
 
-Compatible with Stardew Valley 1.1+ on Linux, Mac, and Windows. Requires SMAPI 1.9+.
+Compatible with Stardew Valley 1.2+ on Linux, Mac, and Windows. Requires SMAPI 2.0+.
 
 ## Install
-1. [Install the latest version of SMAPI](https://github.com/Pathoschild/SMAPI/releases).
-2. Download the mod from the [releases page](https://github.com/ADoby/SimpleSprinkler/releases).
+1. [Install the latest version of SMAPI](https://smapi.io).
+2. [Download the mod](https://www.nexusmods.com/stardewvalley/mods/76).
 3. Unzip it into your game's `Mods` folder.
 4. Run the game using SMAPI.
 

--- a/SimpleSprinkler/Framework/GridHelper.cs
+++ b/SimpleSprinkler/Framework/GridHelper.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+
+namespace SimpleSprinkler.Framework
+{
+    /// <summary>Encapsulates the logic for building sprinkler grids.</summary>
+    internal class GridHelper
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The mod configuration.</summary>
+        private readonly SimpleConfig Config;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="config">The mod configuration.</param>
+        public GridHelper(SimpleConfig config)
+        {
+            this.Config = config;
+        }
+
+        /// <summary>Get the coverage radius for a given sprinkler.</summary>
+        /// <param name="sprinklerId">The sprinkler ID.</param>
+        /// <returns>Returns the sprinkler coverage radius, or -1 if it's not a valid sprinkler.</returns>
+        public int GetRadius(int sprinklerId)
+        {
+            foreach (var sprinkler in this.Config.Radius)
+            {
+                if (sprinklerId == sprinkler.Key)
+                    return (int)sprinkler.Value;
+            }
+
+            return -1;
+        }
+
+        /// <summary>Get the tiles covered by the given sprinkler.</summary>
+        /// <param name="sprinklerId">The sprinkler ID.</param>
+        /// <param name="origin">The sprinkler's tile position.</param>
+        public IEnumerable<Vector2> GetGrid(int sprinklerId, Vector2 origin)
+        {
+            // get range
+            int radius = this.GetRadius(sprinklerId);
+            if (radius == -1)
+                return new Vector2[0];
+
+            // get grid
+            switch (Config.CalculationMethod)
+            {
+                case CalculationMethods.BOX:
+                    return this.GetCircleOrBoxGrid(origin, radius, circle: false);
+                case CalculationMethods.CIRCLE:
+                    return this.GetCircleOrBoxGrid(origin, radius, circle: true);
+                case CalculationMethods.HORIZONTAL:
+                    return this.GetHorizontalGrid(origin, radius);
+                case CalculationMethods.VERTICAL:
+                    return this.CalculateVertical(origin, radius);
+                default:
+                    return new Vector2[0];
+            }
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Get a circular or box grid.</summary>
+        /// <param name="origin">The central tile position.</param>
+        /// <param name="radius">The grid radius (excluding the origin).</param>
+        /// <param name="circle">Whether to draw a circle; else a box.</param>
+        private IEnumerable<Vector2> GetCircleOrBoxGrid(Vector2 origin, float radius, bool circle)
+        {
+            for (float x = origin.X - radius; x <= origin.X + radius; x++)
+            {
+                for (float y = origin.Y - radius; y <= origin.Y + radius; y++)
+                {
+                    Vector2 position = new Vector2(x, y);
+
+                    //Circle Mode Clamp, AwayFromZero is used to get a cleaner look which creates longer outer edges
+                    if (circle && Math.Round(Vector2.Distance(origin, position), MidpointRounding.AwayFromZero) > radius)
+                        continue;
+
+                    yield return new Vector2(x, y);
+                }
+            }
+        }
+
+        /// <summary>Get a horizontal grid.</summary>
+        /// <param name="origin">The central tile position.</param>
+        /// <param name="radius">The grid radius (excluding the origin).</param>
+        private IEnumerable<Vector2> GetHorizontalGrid(Vector2 origin, float radius)
+        {
+            // horizontal tiles
+            for (float x = origin.X - radius; x <= origin.X + radius; x++)
+                yield return new Vector2(x, origin.Y);
+        }
+
+        /// <summary>Get a vertical grid.</summary>
+        /// <param name="origin">The central tile position.</param>
+        /// <param name="radius">The grid radius (excluding the origin).</param>
+        private IEnumerable<Vector2> CalculateVertical(Vector2 origin, float radius)
+        {
+            for (float y = origin.Y - radius; y <= origin.Y + radius; y++)
+                yield return new Vector2(origin.X, y);
+        }
+    }
+}

--- a/SimpleSprinkler/Framework/SimpleSprinklerApi.cs
+++ b/SimpleSprinkler/Framework/SimpleSprinklerApi.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+
+namespace SimpleSprinkler.Framework
+{
+    /// <summary>The API which provides access to Simple Sprinkler for other mods.</summary>
+    public class SimpleSprinklerApi : ISimplerSprinklerApi
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The mod configuration.</summary>
+        private readonly SimpleConfig Config;
+
+        /// <summary>Encapsulates the logic for building sprinkler grids.</summary>
+        private readonly GridHelper GridHelper;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="config">The mod configuration.</param>
+        /// <param name="gridHelper">Encapsulates the logic for building sprinkler grids.</param>
+        internal SimpleSprinklerApi(SimpleConfig config, GridHelper gridHelper)
+        {
+            this.Config = config;
+            this.GridHelper = gridHelper;
+        }
+
+        /// <summary>Get the relative tile coverage for supported sprinkler IDs (additive to the game's default coverage).</summary>
+        public IDictionary<int, Vector2[]> GetNewSprinklerCoverage()
+        {
+            IDictionary<int, Vector2[]> coverage = new Dictionary<int, Vector2[]>();
+            foreach (int sprinklerId in this.Config.Radius.Keys)
+                coverage[sprinklerId] = this.GridHelper.GetGrid(sprinklerId, Vector2.Zero).ToArray();
+            return coverage;
+        }
+    }
+}

--- a/SimpleSprinkler/ISimplerSprinklerApi.cs
+++ b/SimpleSprinkler/ISimplerSprinklerApi.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+
+namespace SimpleSprinkler
+{
+    /// <summary>The API which provides access to Simple Sprinkler for other mods.</summary>
+    public interface ISimplerSprinklerApi
+    {
+        /// <summary>Get the relative tile coverage for supported sprinkler IDs (additive to the game's default coverage).</summary>
+        IDictionary<int, Vector2[]> GetNewSprinklerCoverage();
+    }
+}

--- a/SimpleSprinkler/Properties/AssemblyInfo.cs
+++ b/SimpleSprinkler/Properties/AssemblyInfo.cs
@@ -1,36 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("SimpleSprinkler")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("SimpleSprinkler")]
-[assembly: AssemblyCopyright("Stardew Valley")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0473de39-c05c-4d22-8497-b06eae6cdac0")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyFileVersion("1.6.0")]

--- a/SimpleSprinkler/SimpleSprinkler.csproj
+++ b/SimpleSprinkler/SimpleSprinkler.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>SimpleSprinkler</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,20 +46,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/SimpleSprinkler/SimpleSprinkler.csproj
+++ b/SimpleSprinkler/SimpleSprinkler.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Framework\CalculationMethods.cs" />
+    <Compile Include="Framework\GridHelper.cs" />
     <Compile Include="Framework\SimpleConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleSprinklerMod.cs" />

--- a/SimpleSprinkler/SimpleSprinkler.csproj
+++ b/SimpleSprinkler/SimpleSprinkler.csproj
@@ -37,6 +37,8 @@
     <Compile Include="Framework\CalculationMethods.cs" />
     <Compile Include="Framework\GridHelper.cs" />
     <Compile Include="Framework\SimpleConfig.cs" />
+    <Compile Include="Framework\SimpleSprinklerApi.cs" />
+    <Compile Include="ISimplerSprinklerApi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleSprinklerMod.cs" />
   </ItemGroup>

--- a/SimpleSprinkler/SimpleSprinklerMod.cs
+++ b/SimpleSprinkler/SimpleSprinklerMod.cs
@@ -33,6 +33,12 @@ namespace SimpleSprinkler
             LocationEvents.CurrentLocationChanged += LocationEvents_CurrentLocationChanged;
         }
 
+        /// <summary>Get an API that other mods can access. This is always called after <see cref="Entry" />.</summary>
+        public override object GetApi()
+        {
+            return new SimpleSprinklerApi(this.Config, this.GridHelper);
+        }
+
 
         /*********
         ** Private methods

--- a/SimpleSprinkler/SimpleSprinklerMod.cs
+++ b/SimpleSprinkler/SimpleSprinklerMod.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Microsoft.Xna.Framework;
+﻿using System.Linq;
 using SimpleSprinkler.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -9,21 +7,28 @@ using StardewValley.TerrainFeatures;
 
 namespace SimpleSprinkler
 {
+    /// <summary>The mod entry class.</summary>
     internal class SimpleSprinklerMod : Mod
     {
         /*********
         ** Properties
         *********/
+        /// <summary>The mod configuration.</summary>
         private SimpleConfig Config;
-        private GameLocation Location;
+
+        /// <summary>Encapsulates the logic for building sprinkler grids.</summary>
+        private GridHelper GridHelper;
 
 
         /*********
         ** Public methods
         *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             this.Config = helper.ReadConfig<SimpleConfig>();
+            this.GridHelper = new GridHelper(this.Config);
 
             LocationEvents.CurrentLocationChanged += LocationEvents_CurrentLocationChanged;
         }
@@ -32,103 +37,36 @@ namespace SimpleSprinkler
         /*********
         ** Private methods
         *********/
-        /****
-        ** Event handlers
-        ****/
+        /// <summary>The method called when the player enters a new location.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
         private void LocationEvents_CurrentLocationChanged(object sender, EventArgsCurrentLocationChanged e)
         {
-            if (!Config.Locations.Contains(e.NewLocation.Name))
-                return;
-            Location = e.NewLocation;
-            foreach (var obj in Location.Objects.Values)
-                this.CalculateSimpleSprinkler(obj.ParentSheetIndex, obj.TileLocation, SetWatered);
+            if (this.Config.Locations.Contains(e.NewLocation.Name))
+                this.ApplyWatering(e.NewLocation);
         }
 
-        /****
-        ** Methods
-        ****/
-        private void SetWatered(Vector2 position)
+        /// <summary>Apply watering for supported sprinklers in a location.</summary>
+        /// <param name="location">The location whose sprinklers to apply.</param>
+        private void ApplyWatering(GameLocation location)
         {
-            if (Location.terrainFeatures.ContainsKey(position) && Location.terrainFeatures[position] is HoeDirt)
-                ((HoeDirt)Location.terrainFeatures[position]).state = HoeDirt.watered;
-        }
-
-        private bool IsSimpleSprinkler(int parentSheetIndex, out float range)
-        {
-            foreach (var sprinkler in this.Config.Radius)
+            // get sprinklers
+            var sprinklers = location.Objects.Values.Where(obj => this.IsSprinkler(obj.parentSheetIndex));
+            foreach (Object sprinkler in sprinklers)
             {
-                if (parentSheetIndex == sprinkler.Key)
+                foreach (var tile in this.GridHelper.GetGrid(sprinkler.parentSheetIndex, sprinkler.TileLocation))
                 {
-                    range = sprinkler.Value;
-                    return true;
-                }
-            }
-            range = 0f;
-            return false;
-        }
-
-        private void CalculateSimpleSprinkler(int parentSheetIndex, Vector2 start, Action<Vector2> wateringHandler)
-        {
-            if (wateringHandler == null)
-                return;
-            float range;
-            if (IsSimpleSprinkler(parentSheetIndex, out range) == false)
-                return;
-            CalculateSimpleSprinkler(range, start, wateringHandler);
-        }
-
-        private void CalculateSimpleSprinkler(float range, Vector2 start, Action<Vector2> wateringHandler)
-        {
-            if (wateringHandler == null)
-                return;
-            switch (Config.CalculationMethod)
-            {
-                case CalculationMethods.BOX:
-                    CalculateCircleAndBox(start, range, wateringHandler, false);
-                    break;
-                case CalculationMethods.CIRCLE:
-                    CalculateCircleAndBox(start, range, wateringHandler, true);
-                    break;
-                case CalculationMethods.HORIZONTAL:
-                    CalculateHorizontal(start, range, wateringHandler, true);
-                    break;
-                case CalculationMethods.VERTICAL:
-                    CalculateVertical(start, range, wateringHandler, true);
-                    break;
-            }
-        }
-
-        private void CalculateCircleAndBox(Vector2 start, float range, Action<Vector2> wateringHandler, bool circle)
-        {
-            Vector2 location = start;
-            for (location.X = start.X - range; location.X <= start.X + range; location.X++)
-            {
-                for (location.Y = start.Y - range; location.Y <= start.Y + range; location.Y++)
-                {
-                    //Circle Mode Clamp, AwayFromZero is used to get a cleaner look which creates longer outer edges
-                    if (circle && Math.Round(Vector2.Distance(start, location), MidpointRounding.AwayFromZero) > range)
-                        continue;
-                    wateringHandler.Invoke(location);
+                    if (location.terrainFeatures.TryGetValue(tile, out TerrainFeature terrainFeature) && terrainFeature is HoeDirt dirt)
+                        dirt.state = HoeDirt.watered;
                 }
             }
         }
 
-        private void CalculateHorizontal(Vector2 start, float range, Action<Vector2> wateringHandler, bool circle)
+        /// <summary>Get whether the given object ID matches a supported sprinkler.</summary>
+        /// <param name="objectId">The object ID.</param>
+        private bool IsSprinkler(int objectId)
         {
-            Vector2 location = start;
-            for (location.X = start.X - range; location.X <= start.X + range; location.X++)
-            {
-                wateringHandler.Invoke(location);
-            }
-        }
-
-        private void CalculateVertical(Vector2 start, float range, Action<Vector2> wateringHandler, bool circle)
-        {
-            Vector2 location = start;
-            for (location.Y = start.Y - range; location.Y <= start.Y + range; location.Y++)
-            {
-                wateringHandler.Invoke(location);
-            }
+            return this.Config.Radius.ContainsKey(objectId);
         }
     }
 }

--- a/SimpleSprinkler/manifest.json
+++ b/SimpleSprinkler/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "SimpleSprinkler",
   "Author": "tZed",
-  "Version": "1.5.0",
+  "Version": "1.6.0",
   "Description": "Lets you customise your sprinkler coverage radius.",
   "UniqueID": "tZed.SimpleSprinkler",
   "EntryDll": "SimpleSprinkler.dll",

--- a/SimpleSprinkler/manifest.json
+++ b/SimpleSprinkler/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "SimpleSprinkler",
   "Author": "tZed",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 5,
-    "PatchVersion": 0,
-    "Build": null
-  },
+  "Version": "1.5.0",
   "Description": "Lets you customise your sprinkler coverage radius.",
   "UniqueID": "tZed.SimpleSprinkler",
-  "EntryDll": "SimpleSprinkler.dll"
+  "EntryDll": "SimpleSprinkler.dll",
+  "MinimumApiVersion": "2.0",
+  "UpdateKeys": [ "Nexus:76" ]
 }

--- a/SimpleSprinkler/packages.config
+++ b/SimpleSprinkler/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This pull request...

* Adds a [mod-provided API](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Mod-provided_APIs) so other mods can access the custom sprinkler coverage. For example, I'll be using this to support Simple Sprinklers in my [Data Maps](https://www.nexusmods.com/stardewvalley/mods/1691) mod. Sample usage:
  ```cs
  /// <summary>The API provided by the Simple Sprinkler mod.</summary>
  public interface ISimplerSprinklerApi
  {
      /// <summary>Get the relative tile coverage for supported sprinkler IDs (additive to the game's default coverage).</summary>
      IDictionary<int, Vector2[]> GetNewSprinklerCoverage();
  }
  ```
  ```cs
  ISimplerSprinklerApi api = helper.ModRegistry.GetApi<ISimplerSprinklerApi>("tZed.SimpleSprinkler");
  if (api != null)
     var coverage = api.GetNewSprinklerCoverage();
  ```
* Enables [automatic update checks](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Update_checks).
* Updates `manifest.json` format for SMAPI 2.0+.
* Updates the mod build config package.

If these changes look fine, can you release [SimpleSprinkler 1.6.zip](https://github.com/ADoby/SimpleSprinkler/files/1613916/SimpleSprinkler.1.6.zip) to the [Nexus Mods page](https://www.nexusmods.com/stardewvalley/mods/76)?